### PR TITLE
Docker 컨테이너 환경 설정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 # pyproject.toml & uv.lock 복사 및 설치
 COPY ./pyproject.toml ./uv.lock ./
 
-RUN uv pip install --system .
+RUN uv pip install --system .[dev]
 
 # 애플리케이션 코드 복사
 COPY . .
@@ -26,5 +26,7 @@ COPY . .
 # 포트 설정
 EXPOSE 8000
 
-# Django 개발 서버 실행
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+# 변경된 코드: 스크립트를 사용하여 애플리케이션 실행
+COPY ./scripts /scripts
+RUN chmod +x /scripts/run.sh
+CMD ["/scripts/run.sh"]

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -7,7 +7,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent.parent
 DEBUG = True
 SECRET_KEY = 'dev-secret-key'  # 개발용 임시 키
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 # 데이터베이스 (개발용, SQLite 예시)
 DATABASES = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "django>=5.2.5",
     "djangorestframework>=3.15.2",
+    "gunicorn",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
  Django 프로젝트 Docker 컨테이너화 완료

  1. Dockerfile 작성
   - 프로젝트 실행에 필요한 모든 환경과 의존성을 정의하는 Dockerfile을 루트에 추가
   - Python 3.12 이미지를 기반으로 uv를 사용하여 pyproject.toml의 모든 패키지(개발용 포함)를 설치

  2. 실행 스크립트(`run.sh`) 적용
   - gunicorn 프로덕션 서버로 앱을 실행하도록 scripts/run.sh를 컨테이너의 기본 실행 명령(CMD)으로 설정
   - 컨테이너 시작 시 DB 마이그레이션 같은 초기화 작업을 자동으로 수행

  3. 의존성 및 설정 수정
   - gunicorn을 프로젝트의 정식 의존성으로 추가
   - 컨테이너 환경에서 Django가 정상적으로 요청을 수신하도록 ALLOWED_HOSTS 설정을 수정

  4. 팀원 사용법
   - 이미지 빌드: docker build -t viral-marketing-app .
   - 컨테이너 실행: docker run -d -p 8000:8000 viral-marketing-app